### PR TITLE
Patch 2 to test CI

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1248,7 +1248,7 @@ class ModelsCommand extends Command
             return '\\' . $className;
         }
 
-        $namespace = $this->getNamespace($model);
+        $namespace = $reflection->getNamespaceName();
         $classIsInGlobalNamespace = strcasecmp($namespace, '') === 0;
         $classIsInTheSameNamespace = strpos($className, $namespace) === 0;
         if (!$classIsInGlobalNamespace && $classIsNotInExternalFile && $classIsInTheSameNamespace) {
@@ -1258,13 +1258,6 @@ class ModelsCommand extends Command
 
         $usedClassNames = $this->getUsedClassNames($reflection);
         return $usedClassNames[$className] ?? ('\\' . $className);
-    }
-
-    protected function getNamespace(object $model): string
-    {
-        $class = get_class($model);
-        $pos = strrpos($class, '\\');
-        return substr($class, 0, $pos);
     }
 
     /**

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1248,8 +1248,22 @@ class ModelsCommand extends Command
             return '\\' . $className;
         }
 
+        $namespace = $this->getNamespace($model);
+        $classIsInGlobalNamespace = strcasecmp($namespace, '') === 0;
+        $classIsInTheSameNamespace = strpos($className, $namespace) === 0;
+        if (!$classIsInGlobalNamespace && $classIsNotInExternalFile && $classIsInTheSameNamespace) {
+            $path = explode('\\', $className);
+            return array_pop($path);
+        }
+
         $usedClassNames = $this->getUsedClassNames($reflection);
         return $usedClassNames[$className] ?? ('\\' . $className);
+    }
+
+    protected function getNamespace(object $model): string {
+        $class = get_class($model);
+        $pos = strrpos($class, '\\');
+        return substr($class, 0, $pos);
     }
 
     /**

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1260,7 +1260,8 @@ class ModelsCommand extends Command
         return $usedClassNames[$className] ?? ('\\' . $className);
     }
 
-    protected function getNamespace(object $model): string {
+    protected function getNamespace(object $model): string
+    {
         $class = get_class($model);
         $pos = strrpos($class, '\\');
         return substr($class, 0, $pos);

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithForcedFqn/Models/AnotherModelSameNamespace.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithForcedFqn/Models/AnotherModelSameNamespace.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AnotherModelSameNamespace extends Model
+{
+}

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithForcedFqn/Models/Post.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithForcedFqn/Models/Post.php
@@ -17,6 +17,11 @@ class Post extends Model
         return $this->hasMany(Post::class);
     }
 
+    public function anotherModels(): HasMany
+    {
+        return $this->hasMany(AnotherModelSameNamespace::class);
+    }
+
     public function scopeNull($query, string $unusedParam)
     {
         return $query;

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithForcedFqn/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithForcedFqn/__snapshots__/Test__test__1.php
@@ -5,6 +5,25 @@ declare(strict_types=1);
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models;
 
 use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\AnotherModelSameNamespace
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\AnotherModelSameNamespace newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\AnotherModelSameNamespace newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\AnotherModelSameNamespace query()
+ * @mixin \Eloquent
+ */
+class AnotherModelSameNamespace extends Model
+{
+}
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models;
+
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
@@ -84,6 +103,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property string $macaddress_not_nullable
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\AnotherModelSameNamespace[] $anotherModels
+ * @property-read int|null $another_models_count
  * @property-read \Illuminate\Database\Eloquent\Collection|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post[] $posts
  * @property-read int|null $posts_count
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post newModelQuery()
@@ -175,6 +196,11 @@ class Post extends Model
     public function posts(): HasMany
     {
         return $this->hasMany(Post::class);
+    }
+
+    public function anotherModels(): HasMany
+    {
+        return $this->hasMany(AnotherModelSameNamespace::class);
     }
 
     public function scopeNull($query, string $unusedParam)

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/Models/AnotherModelSameNamespace.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/Models/AnotherModelSameNamespace.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqn\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AnotherModelSameNamespace extends Model
+{
+}

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/Models/Post.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/Models/Post.php
@@ -39,6 +39,11 @@ class Post extends Model
         return $this->hasMany(Post::class);
     }
 
+    public function anotherModels(): HasMany
+    {
+        return $this->hasMany(AnotherModelSameNamespace::class);
+    }
+
     public function scopeNull($query, string $unusedParam)
     {
         return $query;

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/__snapshots__/Test__test__1.php
@@ -4,6 +4,25 @@ declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqn\Models;
 
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqn\Models\AnotherModelSameNamespace
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder|AnotherModelSameNamespace newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|AnotherModelSameNamespace newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|AnotherModelSameNamespace query()
+ * @mixin \Eloquent
+ */
+class AnotherModelSameNamespace extends Model
+{
+}
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqn\Models;
+
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqn\Casts\CastType;
 use Eloquent;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
@@ -90,6 +109,8 @@ use Illuminate\Support\Carbon;
  * @property string $macaddress_not_nullable
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
+ * @property-read Collection|AnotherModelSameNamespace[] $anotherModels
+ * @property-read int|null $another_models_count
  * @property-read Collection|Post[] $posts
  * @property-read int|null $posts_count
  * @method static EloquentBuilder|Post newModelQuery()
@@ -197,6 +218,11 @@ class Post extends Model
     public function posts(): HasMany
     {
         return $this->hasMany(Post::class);
+    }
+
+    public function anotherModels(): HasMany
+    {
+        return $this->hasMany(AnotherModelSameNamespace::class);
     }
 
     public function scopeNull($query, string $unusedParam)

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqnInExternalFile/Models/AnotherModelSameNamespace.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqnInExternalFile/Models/AnotherModelSameNamespace.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqnInExternalFile\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AnotherModelSameNamespace extends Model
+{
+}

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqnInExternalFile/Models/Post.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqnInExternalFile/Models/Post.php
@@ -7,6 +7,10 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqnInExternalFile\Builders\EMaterialQueryBuilder;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @package Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqnInExternalFile\Models
+ * @property AnotherModelSameNamespace $someProp
+ */
 class Post extends Model
 {
     public function newEloquentBuilder($query): EMaterialQueryBuilder

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqnInExternalFile/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqnInExternalFile/__snapshots__/Test__test__1.php
@@ -12,8 +12,21 @@
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqnInExternalFile\Models{
 /**
+ * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqnInExternalFile\Models\AnotherModelSameNamespace
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder|AnotherModelSameNamespace newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|AnotherModelSameNamespace newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|AnotherModelSameNamespace query()
+ */
+	class AnotherModelSameNamespace extends \Eloquent {}
+}
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqnInExternalFile\Models{
+/**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqnInExternalFile\Models\Post
  *
+ * @package Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqnInExternalFile\Models
+ * @property AnotherModelSameNamespace $someProp
  * @property integer $id
  * @property string|null $char_nullable
  * @property string $char_not_nullable

--- a/tests/Console/ModelsCommand/Relations/Models/AnotherModelSameNamespace.php
+++ b/tests/Console/ModelsCommand/Relations/Models/AnotherModelSameNamespace.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AnotherModelSameNamespace extends Model
+{
+}

--- a/tests/Console/ModelsCommand/Relations/Models/Simple.php
+++ b/tests/Console/ModelsCommand/Relations/Models/Simple.php
@@ -78,6 +78,11 @@ class Simple extends Model
 
     // Custom relations
 
+    public function relationBelongsToInTheSameNamespace(): BelongsTo
+    {
+        return $this->belongsTo(AnotherModelSameNamespace::class);
+    }
+
     public function relationBelongsToInAnotherNamespace(): BelongsTo
     {
         return $this->belongsTo(AnotherModel::class);

--- a/tests/Console/ModelsCommand/Relations/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Relations/__snapshots__/Test__test__1.php
@@ -5,6 +5,25 @@ declare(strict_types=1);
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models;
 
 use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\AnotherModelSameNamespace
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder|AnotherModelSameNamespace newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|AnotherModelSameNamespace newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|AnotherModelSameNamespace query()
+ * @mixin \Eloquent
+ */
+class AnotherModelSameNamespace extends Model
+{
+}
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models;
+
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
@@ -75,6 +94,7 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
  * @property integer $id
  * @property-read Simple|null $relationBelongsTo
  * @property-read AnotherModel|null $relationBelongsToInAnotherNamespace
+ * @property-read AnotherModelSameNamespace|null $relationBelongsToInTheSameNamespace
  * @property-read \Illuminate\Database\Eloquent\Collection|Simple[] $relationBelongsToMany
  * @property-read int|null $relation_belongs_to_many_count
  * @property-read \Illuminate\Database\Eloquent\Collection|Simple[] $relationBelongsToManyWithSub
@@ -162,6 +182,11 @@ class Simple extends Model
     }
 
     // Custom relations
+
+    public function relationBelongsToInTheSameNamespace(): BelongsTo
+    {
+        return $this->belongsTo(AnotherModelSameNamespace::class);
+    }
 
     public function relationBelongsToInAnotherNamespace(): BelongsTo
     {


### PR DESCRIPTION
## Summary
When className is in the same namespace as the class which PHP doc is being generated for, return the class name without the namespace.
Full class name is still being written if it's write to the external file, or if it's a global namespace, or if FQCN is forced.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
